### PR TITLE
feature: start, shutdown

### DIFF
--- a/src/exmachina/lib/helper.py
+++ b/src/exmachina/lib/helper.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import asyncio
 import contextvars
 import functools
+import inspect
 import re
 from collections import deque
+from typing import Any, Callable, Coroutine
 
 _times = dict(d=86400.0, h=3600.0, m=60.0, s=1.0, ms=0.001)
 _r = (
@@ -136,3 +138,11 @@ class TimeSemaphore:
             if not waiter.done():
                 waiter.set_result(None)
                 return
+
+
+async def execute_functions(funcs: list[Callable[[], Coroutine[Any, Any, None]] | Callable[[], None]]):
+    for func in funcs:
+        if inspect.iscoroutinefunction(func):
+            await func()  # type: ignore
+        elif inspect.isfunction(func) or inspect.ismethod(func):
+            func()

--- a/tests/core/test_machina.py
+++ b/tests/core/test_machina.py
@@ -1,4 +1,5 @@
 import asyncio
+
 import pytest
 
 from exmachina.core.exception import MachinaException
@@ -126,3 +127,25 @@ class TestMachina:
                 event.execute("test_not_exist")
 
         await bot.run()
+
+    @pytest.mark.asyncio
+    async def test_start_shutdown(self):
+        expect = {"async_start": False, "start": False, "async_shutdown": False, "shutdown": False}
+
+        async def async_start():
+            expect["async_start"] = True
+
+        def start():
+            expect["start"] = True
+
+        async def async_shutdown():
+            expect["async_shutdown"] = True
+
+        def shutdown():
+            expect["shutdown"] = True
+
+        bot = Machina(on_startup=[async_start, start], on_shutdown=[async_shutdown, shutdown])
+
+        await bot.run()
+
+        assert all(expect.values())


### PR DESCRIPTION
```python
expect = {"async_start": False, "start": False, "async_shutdown": False, "shutdown": False}

async def async_start():
    expect["async_start"] = True

def start():
    expect["start"] = True

async def async_shutdown():
    expect["async_shutdown"] = True

def shutdown():
    expect["shutdown"] = True

bot = Machina(on_startup=[async_start, start], on_shutdown=[async_shutdown, shutdown])

await bot.run()
```

`bot.run()`の最初と最後に実行する関数を指定できるようにした